### PR TITLE
Fix incorrect storage of audience_configuration to $config variable

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -45,7 +45,7 @@ class Configuration
 
     public static function fromGlobals(): self
     {
-        $config = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['audience_studio']['storageConfiguration'] ?? [];
+        $config = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['audience_studio'] ?? [];
         if (empty($config)) {
             throw new \RuntimeException('Configuration for audience studio is missing', 1602767075);
         }


### PR DESCRIPTION
Because `$config` was storing the `storageConfiguration` sub-array and not the whole configuration array, the `RuntimeException` is thrown.